### PR TITLE
[MB-11557] Make Config Notifier fire only if there's something in the report to add

### DIFF
--- a/notifier/notifier/notifier.py
+++ b/notifier/notifier/notifier.py
@@ -40,14 +40,12 @@ def prepare_sns_message(title="", report=None, additional_text=""):
     message (str): the formatted string
     """
     message = f"{title}\n```"
+    send_to_sns = False
     if len(report) > 0:
+        send_to_sns = True
         message += "\n".join([f"{result['resource_type']}: {result['count']}" for result in report])
         LOGGER.info(f"message: {message}")
         message += f"```\n{additional_text}"
-
-    send_to_sns = False
-    if len(message) > 0:
-        send_to_sns = True
 
     return send_to_sns, message
 


### PR DESCRIPTION
Currently, send_to_sns is flipped to true if the message length is greater than 0, which always is true.

Instead, flip send_to_sns to be true if there's anything to add to the report